### PR TITLE
Refine doc for NERD_tree.vim

### DIFF
--- a/doc/NERD_tree.cnx
+++ b/doc/NERD_tree.cnx
@@ -58,12 +58,12 @@ NERD tree 提供以下特性和功能：
         * 文件
         * 目录
         * 符号链接
-        * Windows 快捷方式（.lnk 文件）
+        * Windows 快捷方式（ .lnk 文件）
         * 只读文件
         * 可执行文件
     * 提供许多（可定制的）映射来操作树：
-        * 映射为打开/关闭/浏览目录节点
-        * 映射为在新的/已存在的窗口/标签页中打开文件
+        * 映射为打开、关闭或浏览目录节点
+        * 映射为在新的或已存在的窗口或标签页中打开文件
         * 映射为改变当前树的根节点
         * 映射为在树结构中进行导航
         * ...
@@ -80,16 +80,16 @@ NERD tree 提供以下特性和功能：
         * 如果你重新访问目录树中你以前的会话中访问过的部分，这个目录节点将保持
           你之前打开/关闭它们时的状态
     * 插件会记住在 NERD tree 中的光标位置和窗口位置，这样你就可以把窗口隐藏
-      （或者直接关闭属性窗口），当再次打开它的时候（使用 NERDTreeToggle），
+      （或者直接关闭属性窗口），当再次打开它的时候（使用 NERDTreeToggle ），
       NERD tree 将出现在你最后使用过的位置
     * 你可以为每一个标签页打开一个不相关的 NERD tree，或者跨标签页共享树，或者
       混合使用上面两种方式
-    * 默认情况下，插件会替换默认的文件浏览器（netrw），所以如果你使用 :edit
+    * 默认情况下，插件会替换默认的文件浏览器（ netrw ），所以如果你使用 :edit
       编辑一个目录，一个（轻微修改过的）NERD tree 会出现在当前窗口中
     * 提供一个可编程的菜单系统（模拟右键点击一个节点上）
-        * 提供一个执行基本的文件系统操作的默认菜单插件（新建/删除/移动/复制文
-          件/目录）
-    * 提供一个可添加自己的按键映射的 API
+        * 提供一个执行基本的文件系统操作的默认菜单插件（新建、删除、移动或复制
+          文件及目录）
+    * 提供一个可以添加自定义按键映射的 API
 
 
 ==============================================================================
@@ -105,7 +105,7 @@ NERD tree 提供以下特性和功能：
     如果指定了书签名，会使用书签相应的目录。
     例如： >
         :NERDTree /home/marty/vim7/src
-        :NERDTree foo   (foo 是一个书签名)
+        :NERDTree foo   （ foo 是一个书签名）
 <
 :NERDTreeFromBookmark <书签>                           *:NERDTreeFromBookmark*
     使用 <书签> 的目录作为根目录打开一个新的 NERD tree。使用该命令而不是
@@ -146,10 +146,10 @@ NERD tree 中的书签是一种标记感兴趣的文件或者目录的方式。�
 ------------------------------------------------------------------------------
 2.2.1. 书签表                                          *NERDTreeBookmarkTable*
 
-如果书签表被激活 (参阅 |NERDTree-B| 和 |'NERDTreeShowBookmarks'|)，则会被渲染
-到树状图的上方，你可以双击书签或者使用 |NERDTree-o| 来激活选中文件。
+如果书签表被激活（参阅 |NERDTree-B| 和 |'NERDTreeShowBookmarks'| ），则会被渲
+染到树状图的上方，你可以双击书签或者使用 |NERDTree-o| 来激活选中文件。
 
-另请参阅 |NERDTree-t| 和 |NERDTree-T|
+另请参阅 |NERDTree-t| 和 |NERDTree-T| 。
 
 ------------------------------------------------------------------------------
 2.2.2. 书签命令                                     *NERDTreeBookmarkCommands*
@@ -168,7 +168,7 @@ NERD tree 中的书签是一种标记感兴趣的文件或者目录的方式。�
     注意如果 <书签> 指向一个文件，那么会使用它的父目录。
 
 :RevealBookmark <书签>
-    如果这个节点被缓存在当前的根节点下，它会被展现（即：它的祖先节点会被打开）
+    如果这个节点被缓存在当前的根节点下，它会被展现（即它的祖先节点会被打开），
     并且光标置于其上。
 
 :OpenBookmark <书签>
@@ -179,12 +179,12 @@ NERD tree 中的书签是一种标记感兴趣的文件或者目录的方式。�
     刪除所有指定的书签。如果没有指定书签，会刪除当前节点上的所有书签。
 
 :ClearAllBookmarks
-    刪除所有书签
+    刪除所有书签。
 
 :ReadBookmarks
     重新读取 |'NERDTreeBookmarksFile'| 中的书签。
 
-另请参阅 |:NERDTree| 和 |:NERDTreeFromBookmark|.
+另请参阅 |:NERDTree| 和 |:NERDTreeFromBookmark| 。
 
 ------------------------------------------------------------------------------
 2.2.3. 无效书签                                     *NERDTreeInvalidBookmarks*
@@ -229,8 +229,8 @@ P.......跳转到根节点.............................................|NERDTree
 p.......跳转到当前节点的父节点...................................|NERDTree-p|
 K.......跳转到当前目录下同级的第一个节点.........................|NERDTree-K|
 J.......跳转到当前目录下同级的最后一个节点.......................|NERDTree-J|
-<C-J>...跳转到当前目录下同级的前一个节点.........................|NERDTree-C-J|
-<C-K>...跳转到当前目录下同级的后一个节点.........................|NERDTree-C-K|
+<C-J>...跳转到当前目录下同级的上一个节点.........................|NERDTree-C-J|
+<C-K>...跳转到当前目录下同级的下一个节点.........................|NERDTree-C-K|
 
 C.......将选中目录或文件的父目录设为根节点.......................|NERDTree-C|
 u.......将当前节点的父目录设为根节点.............................|NERDTree-u|
@@ -247,7 +247,7 @@ F.......切换是否显示文件.........................................|NERDTr
 B.......切换是否显示书签表.......................................|NERDTree-B|
 
 q.......关闭 NERD tree 窗口......................................|NERDTree-q|
-A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERDTree-A|
+A.......缩放（最大化/最小化）NERD tree 窗口......................|NERDTree-A|
 ?.......切换是否显示快速帮助.....................................|NERDTree-?|
 
 ------------------------------------------------------------------------------
@@ -272,7 +272,7 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 
 如果一个文件节点被选中，它会在前一个窗口中被打开，但是光标位置不会变。
 
-这个按键组合永远是 "g" + NERDTreeMapActivateNode （请参阅 |NERDTree-o|）。
+这个按键组合永远是 "g" + NERDTreeMapActivateNode （请参阅 |NERDTree-o| ）。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-t*
@@ -310,7 +310,7 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 
 和 |NERDTree-i| 一样，只不过光标不会被移动。
 
-这个按键组合永远是 "g" + NERDTreeMapOpenSplit 的形式（请参阅 |NERDTree-i|）。
+这个按键组合永远是 "g" + NERDTreeMapOpenSplit 的形式（请参阅 |NERDTree-i| ）。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-s*
@@ -324,11 +324,11 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
                                                                  *NERDTree-gs*
 默认映射： gs
 映射选项： 无
-应用对象： files.
+应用对象： 文件
 
 和 |NERDTree-s| 一样，只不过光标不会被移动。
 
-这个按键组合永远是 "g" + NERDTreeMapOpenVSplit 的形式（请参阅 |NERDTree-s|）。
+这个按键组合永远是 "g" + NERDTreeMapOpenVSplit 的形式（请参阅 |NERDTree-s| ）。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-O*
@@ -339,8 +339,8 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 递归打开所选目录。
 
 所有文件和目录被缓存，但是如果一个目录由于文件过滤器（请参阅 |'NERDTreeIgnore'|
-|NERDTree-f|）或者隐藏文件过滤器（请参阅 |'NERDTreeShowHidden'|）而不被显示，那么
-它的内容不会被缓存。这样是便于使用的，尤其是当你有 .svn 目录的时候。
+|NERDTree-f| ）或者隐藏文件过滤器（请参阅 |'NERDTreeShowHidden'| ）而不被显示，
+那么它的内容不会被缓存。这样是便于使用的，尤其是当你有 .svn 目录的时候。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-x*
@@ -364,7 +364,7 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
                                                                   *NERDTree-e*
 默认映射： e
 映射选项： NERDTreeMapOpenExpl
-应用对象： files and directories.
+应用对象： 文件和目录
 
 |:edit| 所选目录，或者所选文件的目录。依据 |'NERDTreeHijackNetrw'| 的设定，可
 以打开一个 NERD tree 或者一个 netrw 。
@@ -383,7 +383,7 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 映射选项： NERDTreeMapJumpRoot
 应用对象： 没有限制
 
-跳转到根节点
+跳转到根节点。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-p*
@@ -391,7 +391,7 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 映射选项： NERDTreeMapJumpParent
 应用对象： 文件和目录
 
-跳转到所选目录的父节点
+跳转到所选目录的父节点。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-K*
@@ -399,7 +399,7 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 映射选项： NERDTreeMapJumpFirstChild
 应用对象： 文件和目录
 
-跳转到当前节点父节点的第一个子节点
+跳转到当前节点父节点的第一个子节点。
 
 如果光标已经在第一个节点上，按照以下做法：
     * 在当前节点父节点的兄弟节点中向后查找，直到找到了一个打开的有子节点的目录
@@ -411,7 +411,7 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 映射选项： NERDTreeMapJumpLastChild
 应用对象： 文件和目录
 
-跳转到当前节点父节点的最后一个子节点
+跳转到当前节点父节点的最后一个子节点。
 
 如果光标已经在最后一个节点上，按照以下做法：
     * 在当前节点父节点的兄弟节点中向前查找，直到找到了一个打开的有子节点的目录
@@ -423,7 +423,7 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 映射选项： NERDTreeMapJumpNextSibling
 应用对象： 文件和目录
 
-跳转到所选节点的后一个兄弟节点。
+跳转到所选节点的下一个兄弟节点。
 
 ------------------------------------------------------------------------------
                                                                 *NERDTree-C-K*
@@ -431,7 +431,7 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 映射选项： NERDTreeMapJumpPrevSibling
 应用对象： 文件和目录
 
-跳转到所选节点的前一个兄弟节点。
+跳转到所选节点的上一个兄弟节点。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-C*
@@ -505,7 +505,7 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 映射选项： NERDTreeMapToggleHidden
 应用对象： 没有限制
 
-切换是否显示隐藏文件（即：以点号开头的文件）
+切换是否显示隐藏文件（即以点号开头的文件）。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-f*
@@ -513,7 +513,7 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 映射选项： NERDTreeMapToggleFilters
 应用对象： 没有限制
 
-切换是否使用文件过滤。详细请参阅|'NERDTreeIgnore'| 。
+切换是否使用文件过滤。详细请参阅 |'NERDTreeIgnore'| 。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-F*
@@ -561,9 +561,9 @@ A.......缩放 (最大化/最小化) NERD tree 窗口......................|NERD
 NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeMenuAPI| ）。这个
 主意是为了模拟大多数文件浏览器都具有的右键菜单。
 
-这个插件有两个默认菜单插件：exec_menuitem.vim 和 fs_menu.vim。fs_menu.vim 添加
-一些基本的新建/删除/移动/复制文件和目录的操作。exec_menuitem.vim 提供了一个菜
-单项来执行可执行文件。
+这个插件有两个默认菜单插件： exec_menuitem.vim 和 fs_menu.vim 。 fs_menu.vim
+添加一些基本的新建、删除、移动或复制文件及目录的操作。 exec_menuitem.vim 提供
+了一个菜单项来执行可执行文件。
 
 相关标签： |NERDTree-m| |NERDTreeApi|
 
@@ -576,7 +576,7 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 
 提供下面的选项，可以定制 NERD tree 的行为。这些选项需要被设置在您的 vimrc 中。
 
-|'loaded_nerd_tree'|            不使用 NERD tree 插件
+|'loaded_nerd_tree'|            不使用 NERD tree 插件。
 
 |'NERDTreeAutoCenter'|          当光标移动到距离顶部/底部指定的距离的时候，控
                                 制 NERD tree 是否将光标所在位置自动设置为窗口
@@ -624,13 +624,13 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 
 |'NERDTreeWinSize'|             设置 NERD tree 窗口被打开时的大小。
 
-|'NERDTreeMinimalUI'|           禁止显示 'Bookmarks' 和 'Press ? for help'
+|'NERDTreeMinimalUI'|           禁止显示 'Bookmarks' 和 'Press ? for help' 。
 
 |'NERDTreeDirArrows'|           告诉 NERD tree 显示目录的时候使用箭头代替 + ~ 。
 
 |'NERDTreeCascadeOpenSingleChildDir'|
-                              当所选目录只有一个子节点并且该节点是目录的时候，
-                                级联展开。
+                                当所选目录只有一个子节点并且该节点是目录的时
+                                候，级联展开。
 
 |'NERDTreeAutoDeleteBuffer'|    告诉 NERD tree 当文件被上下文菜单命令删除或重
                                 命名的时候，自动删除缓冲区。
@@ -650,7 +650,7 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 取值范围： 0 或 1
 默认值： 1
 
-如果设置为1，当光标移动到距顶部/底部的行数是 |'NERDTreeAutoCenterThreshold'|
+如果设置为 1 ，当光标移动到距顶部/底部的行数是 |'NERDTreeAutoCenterThreshold'|
 指定的行范围以内的时候，NERD tree 窗口会将光标所在位置自动设置为窗口的中心。
 
 这个选项只会对树导航映射作出反应，
@@ -678,7 +678,7 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
     boner.c
     Foo.c
 <
-但是，如果你把选项设置为1，上面的节点会按下面的方式排序： >
+但是，如果你把选项设置为 1 ，上面的节点会按下面的方式排序： >
     Baz.c
     Foo.c
     bar.c
@@ -693,9 +693,9 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 
 用这个选项告诉插件什么时候（如果真的需要）改变 Vim 的当前工作目录（CWD）。
 
-如果设置为0，当前工作目录（CWD）永远不会被 NERD tree 改变。
+如果设置为 0 ，当前工作目录（CWD）永远不会被 NERD tree 改变。
 
-如果设置为1，当前工作目录（CWD）会在第一次加载 NERD tree 的时候被改变为它初
+如果设置为 1 ，当前工作目录（CWD）会在第一次加载 NERD tree 的时候被改变为它初
 始化的目录。比如：
 
 如果你使用下面的命令启动 NERD tree ： >
@@ -704,7 +704,7 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 然后当前工作目录（CWD）会被改变为 /home/marty/foobar 并且不会被再次改变，除非
 你使用相似的命令初始化了另一个 NERD tree 。
 
-如果这个选项被设置为2，插件的行为和被设置为1类似，只不过当树的根目录被改变的时
+如果这个选项被设置为 2 ，插件的行为和被设置为 1 类似，只不过当树的根目录被改变的时
 候当前工作目录（CWD）也会被改变。例如，如果当前工作目录（CWD）是
 /home/marty/foobar 并且你把 /home/marty/foobar/baz 设置为了新的根节点，当前工
 作目录（CWD）也会被改变为 /home/marty/foobar/baz 。
@@ -714,7 +714,7 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 取值范围： 0 或 1
 默认值： 1
 
-如果设置为1，NERD tree 缓冲区内的当前光标所在行会被高亮，使用 |'cursorline'|
+如果设置为 1 ，NERD tree 缓冲区内的当前光标所在行会被高亮，使用 |'cursorline'|
 来完成。
 
 ------------------------------------------------------------------------------
@@ -722,7 +722,7 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 取值范围： 0 或 1
 默认值： 1
 
-如果设置为1，当执行 >
+如果设置为 1 ，当执行 >
     :edit <some directory>
 <
 会在目标窗口打开一个“次等”的 NERD tree 来代替 netrw 。
@@ -737,7 +737,7 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 默认值： ['\~$']
 
 这个选项用来指定哪些文件会被 NERD tree 忽略。它必须是一个正则表达式的列表。当
-NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配的任何文件/目录
+NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配的任何文件及目录
 都不会被显示。
 
 例如你把下面的设置放到你的 vimrc 中： >
@@ -762,7 +762,7 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 取值范围： 0 或 1
 默认值： 0
 
-如果设置为1，会考虑 |'wildignore'| 选项。
+如果设置为 1 ，会考虑 |'wildignore'| 选项。
 
 ------------------------------------------------------------------------------
                                                      *'NERDTreeBookmarksFile'*
@@ -776,30 +776,30 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 取值范围： 0 或 1
 默认值： 1
 
-如果设置为0，书签表不会被排序。
-如果设置为1，书签表会被排序。
+如果设置为 0 ，书签表不会被排序。
+如果设置为 1 ，书签表会被排序。
 
 ------------------------------------------------------------------------------
                                                          *'NERDTreeMouseMode'*
 取值范围： 1，2 或 3
 默认值： 1
 
-如果设置为1，双击一个节点会打开它。
-如果设置为2，单击一个节点会打开目录节点，文件节点需要双击才会打开。
-如果设置为3，单击会打开任何类型的节点。
+如果设置为 1 ，双击一个节点会打开它。
+如果设置为 2 ，单击一个节点会打开目录节点，文件节点需要双击才会打开。
+如果设置为 3 ，单击会打开任何类型的节点。
 
 注意：双击树节点所在行的任何位置都会激活它，但是所有单击激活必须单击节点名称。
 例如，如果有下面的节点： >
     | | |-application.rb
 <
-那么 (为单击激活它) 你必须单击 'application.rb' 中的某个地方。
+那么（为单击激活它）你必须单击 'application.rb' 中的某个地方。
 
 ------------------------------------------------------------------------------
                                                         *'NERDTreeQuitOnOpen'*
 取值范围： 0 或 1
 默认值： 0
 
-如果设置为1，NERD tree 窗口会在用下面的映射打开文件后被关闭： |NERDTree-o| ，
+如果设置为 1 ，NERD tree 窗口会在用下面的映射打开文件后被关闭： |NERDTree-o| ，
 |NERDTree-i| ， |NERDTree-t| 和 |NERDTree-T| 。
 
 ------------------------------------------------------------------------------
@@ -807,7 +807,7 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 取值范围： 0 或 1
 默认值： 0
 
-如果选项设置为1，会显示书签表。
+如果选项设置为 1 ，会显示书签表。
 
 这个选项可以被每个树动态切换，使用 |NERDTree-B| 的按键映射。
 
@@ -816,7 +816,7 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 取值范围： 0 或 1
 默认值： 1
 
-如果这个选项被设置为1，会在 NERD tree 中显示文件。如果设置为0，只有目录被显示。
+如果这个选项被设置为 1 ，会在 NERD tree 中显示文件。如果设置为 0，只有目录被显示。
 
 这个选项可以被每个树动态切换，使用 |NERDTree-F| 的按键映射，并且在你需要导
 航到树的某个部分的时候可以大幅缩减树的节点。
@@ -881,11 +881,11 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 
 注意状态栏是使用 |:let-&| 而不是 |:set| 所以不用转义空格。
 
-将这个选项设置为-1会禁止它，这样就可以使用你自己的全局状态栏设置。
+将这个选项设置为 -1 会禁止它，这样就可以使用你自己的全局状态栏设置。
 
 ------------------------------------------------------------------------------
                                                             *'NERDTreeWinPos'*
-取值范围： "left"（意为左边） 或 "right"（意为右边）
+取值范围： "left" （意为左边） 或 "right" （意为右边）
 默认值： "left"
 
 这个选项用来决定 NERD tree 窗口被显示在屏幕的什么位置。
@@ -916,9 +916,9 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 取值范围： 0 或 1
 默认值： 0
 
-这个选项用来改变树中目录节点的默认外观。当这个选项设置为0的时候，会使用老式的
-长条(|)，+，~ 字符。当设置为1的时候使用右箭头和下箭头。使用下面方式设置这个选
-项： >
+这个选项用来改变树中目录节点的默认外观。当这个选项设置为 0 的时候，会使用老式
+的长条（|），+ ，~ 字符。当设置为 1 的时候使用右箭头和下箭头。使用下面方式设置
+这个选项： >
     let NERDTreeDirArrows=0
     let NERDTreeDirArrows=1
 <
@@ -943,7 +943,7 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 
 当使用上下文菜单来删除或重命名文件的时候，你可能也想删除那个不再可用的缓冲区。
 这个选项没有被设置的时候，你会看到一个询问你是否真的想删除旧的缓冲区的确认信
-息。如果你总是按 'y' ，那么值得把这个选项设置为1。
+息。如果你总是按 'y' ，那么值得把这个选项设置为 1 。
 使用下面的方式来设置这个选项： >
     let NERDTreeAutoDeleteBuffer=0
     let NERDTreeAutoDeleteBuffer=1
@@ -953,8 +953,8 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 4. NERD tree API                                                 *NERDTreeAPI*
 
 NERD tree 插件允许你通过 API 添加自定义的按键映射和菜单项。任何使用 API 的脚本
-需要被放在 ~/.vim/nerdtree_plugin/ (*nix 系统) 或 ~/vimfiles/nerdtree_plugin
-(Windows 系统)。
+需要被放在 ~/.vim/nerdtree_plugin/ （ *nix 系统）或 ~/vimfiles/nerdtree_plugin
+（ Windows 系统）。
 
 插件导出了一些可以用来操作树和/或从中获得信息的原型对象： >
     g:NERDTreePath
@@ -962,7 +962,7 @@ NERD tree 插件允许你通过 API 添加自定义的按键映射和菜单项�
     g:NERDTreeFileNode
     g:NERDTreeBookmark
 <
-请参阅 NERD_tree.vim 中的代码/注释来找到使用这些对象的方法。
+请参阅 NERD_tree.vim 中的代码及注释来找到使用这些对象的方法。
 使用了下面的编码约定：
     * 类成员变量以大写字母开头
     * 实例成员变量以小写字母开头
@@ -980,8 +980,8 @@ NERDTreeAddKeyMap({options})                             *NERDTreeAddKeyMap()*
     "key" - 新映射的触发键
     "callback" - 新按键映射的处理函数
     "quickhelpText" - 在快速帮助中显示的文本（详细请参阅 |NERDTree-?| ）
-    "override" - 如果为1，那么新的按键映射会覆盖任何以前定义的 按键/作用范围。
-    可以用来覆盖默认的按键映射。
+    "override" - 如果为 1 ，那么新的按键映射会覆盖该按键及作用域组合的任何先前
+    定义的映射。可以用来覆盖默认的按键映射。
 
     此外，可以提供一个 "scope" 参数。限制按键映射只在光标在确定的对象上时才被
     激活。那个对象会被传递到处理函数。可能的值为：
@@ -989,8 +989,8 @@ NERDTreeAddKeyMap({options})                             *NERDTreeAddKeyMap()*
         "DirNode" - 目录节点
         "Node" - 文件或目录节点
         "Bookmark" - 书签
-        "all" - 这个按键映射默认不会限制任何作用范围。当它们被使用的时候，处
-        理函数不会被传递任何对象。
+        "all" - 这个按键映射默认不会限制任何作用域。当它们被使用的时候，处理函
+        数不会被传递任何参数。
 
 
     例子： >
@@ -1020,14 +1020,14 @@ NERDTreeAddSubmenu({options})                           *NERDTreeAddSubmenu()*
 
     下面的键是可选的：
     "isActiveCallback" - 一个用来决定这个子菜单是否被显示的快捷键。这个回调函
-    数必须返回0或1。
+    数必须返回 0 或 1 。
     "parent" - 新的子菜单的父菜单（从前一个 NERDTreeAddSubmenu() 的调用返回）。
     如果这个键没有指定值，那么新的子菜单会被现实在顶级菜单中。
 
     参考下面的例子。
 
 NERDTreeAddMenuItem({options})                         *NERDTreeAddMenuItem()*
-    在 NERD tree 菜单中添加一个新的菜单项（详细请参阅 |NERDTreeMenu|）。
+    在 NERD tree 菜单中添加一个新的菜单项（详细请参阅 |NERDTreeMenu| ）。
 
     {options} 必须是一个字典类型，必须包含下面的键：
     "text" - 显示给用户看的菜单项的文本
@@ -1036,7 +1036,7 @@ NERDTreeAddMenuItem({options})                         *NERDTreeAddMenuItem()*
 
     下面的键是可选的：
     "isActiveCallback" - 一个用来决定这个菜单项是否被显示的快捷键。这个回调函
-    数必须返回0或1。
+    数必须返回 0 或 1 。
     "parent" - 如果这个菜单项属于某个子菜单，那么这个键必须被设置。这个键的值
     需要被设置为使用 |NERDTreeAddSubmenu()| 创建子菜单时返回的那个对象。
 
@@ -1091,8 +1091,8 @@ NERDTreeRender()                                            *NERDTreeRender()*
 ==============================================================================
 5. 关于                                                        *NERDTreeAbout*
 
-NERD tree 的作者是一只叫“妈斯拉”（Martyzilla）的十分可怕的怪兽，他在早餐的时候
-配着牛奶和糖大口地吞食小孩子。
+NERD tree 的作者是一只叫“妈斯拉”（ Martyzilla ）的十分可怕的怪兽，他在早餐的时
+候配着牛奶和糖大口地吞食小孩子。
 
 他的电子邮件地址为 martin.grenfell 艾特 gmail 点 com 。他很乐意聆听你的反馈，
 所以请把你对这个插件的建议和/或评论直接发送给他。不要害羞 --- 他能做的最坏的
@@ -1125,13 +1125,13 @@ NERD tree 的作者是一只叫“妈斯拉”（Martyzilla）的十分可怕的
     - 如果没有给 :Bookmark 指定名称，它会使用目标文件/目录的名称(minyoung)
     - 当进行复制、新建和移动操作的时候使用 'file' 补全(EvanDotPro)
     - 很多的错误修复 (paddyoloughlin, sdewald, camthompson, Vitaly
-      Bogdanov, AndrewRadev, mathias, scottstvnsn, kml, wycats, me RAWR!)
+      Bogdanov, AndrewRadev, mathias, scottstvnsn, kml, wycats, 我 吼吼！)
 
 4.1.0
     新特性：
-    - NERDTreeFind to 展现树的当前缓冲区，请参阅 |NERDTreeFind| 。插件合并了
-      FindInNERDTree(作者 Doug McInnes)
-    - NERDTreeQuitOnOpen 对 t/T 映射生效。感谢Stefan Ritter 和 Rémi Prévost
+    - 添加 NERDTreeFind 来展现树的当前缓冲区，请参阅 |NERDTreeFind| 。这实际上
+      合并了 FindInNERDTree 插件（作者 Doug McInnes ）到本脚本中。
+    - NERDTreeQuitOnOpen 对 t/T 映射生效。感谢 Stefan Ritter 和 Rémi Prévost
     - 如果比树窗口宽，缩短根节点。感谢 Victor Gonzalez 。
 
     错误修复:
@@ -1141,13 +1141,13 @@ NERD tree 的作者是一只叫“妈斯拉”（Martyzilla）的十分可怕的
 
 4.0.0
     - 添加一个新的可编程的菜单系统（请参阅 :help NERDTreeMenu ）。
-    - 添加新的 API 来添加菜单/菜单项到菜单系统和添加自定义映射到NERD tree
+    - 添加新的 API 来添加菜单/菜单项到菜单系统和添加自定义映射到 NERD tree
       缓冲区（请参阅 :help NERDTreeAPI ）。
     - 移除旧的 API
     - 添加一个新的映射来最大化/还原 NERD tree 的窗口，感谢
       Guillaume Duranceau 的补丁。详细请参阅 :help NERDTree-A 。
 
-    - 修复次等的 NERD tree (netrw 替换树) 和 NERDTreeQuitOnOpen
+    - 修复次等的 NERD tree （ netrw 替换树） 和 NERDTreeQuitOnOpen
       选项共存的问题，感谢 Curtis Harvey 。
     - 修复插件忽略以点号结尾的目录的问题，感谢 Aggelos Orfanakos 的补丁。
     - 修复 x 按键在树的根节点的问题，感谢 Bryan Venteicher 的补丁。
@@ -1157,10 +1157,10 @@ NERD tree 的作者是一只叫“妈斯拉”（Martyzilla）的十分可怕的
 
 3.1.1
     - 修复每次树窗口被创建的时候一个没有列表没有名字的缓冲区被创建的错误，
-      感谢 Derek Wyatt and owen1
+      感谢 Derek Wyatt 和 owen1
     - 使 <CR> 行为和 'o' 映射一样。
     - 修复文档中一些帮助标签，感谢 strull
-    - 修复使用 :set nohidden和打开前一个缓冲区被修改过的文件中的错误。感
+    - 修复使用 :set nohidden 和打开前一个缓冲区被修改过的文件中的错误。感
       谢 iElectric
     - 其它小修复
 
@@ -1171,9 +1171,10 @@ NERD tree 的作者是一只叫“妈斯拉”（Martyzilla）的十分可怕的
     - 将 NERD tree 的窗口状态栏的默认值设置为一些更加有用的值。请参阅
       :help 'NERDTreeStatusline'
     错误修复:
-    - 替换 netrw 对 "vim <some dir>" 方式打开的也生效(感谢 Alf Mikula 的补丁)
+    - 替换 netrw 对以 "vim <some dir>" 方式打开的 Vim 也生效
+      （感谢 Alf Mikula 的补丁）
     - 修复当前工作目录（CWD）没有被一些操作改变的情况，即使是设置了
-      NERDTreeChDirMode==2（感谢 Lucas S. Buchala ）
+      NERDTreeChDirMode==2 （感谢 Lucas S. Buchala ）
     - 给所有 NERD tree :commands 添加 -bar，这样他们就可以链式调用其他
       :commands。 （感谢 tpope ）
     - 修复设置忽略中的错误 （感谢 nach ）
@@ -1183,10 +1184,10 @@ NERD tree 的作者是一只叫“妈斯拉”（Martyzilla）的十分可怕的
 
 3.0.1
     错误修复:
-    - 修复'hidden' 没有设置时 :NERDTreeToggle 和 :NERDTreeMirror 中的错误
-    - 修复当 <path> 是相对路径并且没有以 ./ 或 ../开头的时候，
+    - 修复 'hidden' 没有设置时 :NERDTreeToggle 和 :NERDTreeMirror 中的错误
+    - 修复当 <path> 是相对路径并且没有以 ./ 或 ../ 开头的时候，
       :NERDTree <path> 会失败的错误，感谢 James Kanze 。
-    - 使按键映射 q 对次等（:e <dir> 形式） NERD tree 生效，感谢 jamessan
+    - 使按键映射 q 对次等（ :e <dir> 形式） NERD tree 生效，感谢 jamessan
     - 修复次等 NERD tree 中大把的错误。
 
     许多疯狂的重构。
@@ -1272,8 +1273,8 @@ NERD tree 而干脆去下载毛片了。
 ==============================================================================
 8. 授权协议                                                  *NERDTreeLicense*
 
-NERD tree 基于“你他妈的想干嘛就干嘛公共许可证”（WTFPL）发布。
-参阅 http://sam.zoy.org/wtfpl/COPYING.
+NERD tree 基于“你他妈的想干嘛就干嘛公共许可证”（ WTFPL ）发布。
+参阅 http://sam.zoy.org/wtfpl/COPYING 。
 
 ==============================================================================
  vim:tw=78:ts=8:ft=help:norl:et:

--- a/doc/NERD_tree.cnx
+++ b/doc/NERD_tree.cnx
@@ -58,7 +58,7 @@ NERD tree 提供以下特性和功能：
         * 文件
         * 目录
         * 符号链接
-        * Windows 快捷方式（ .lnk 文件）
+        * Windows 快捷方式（.lnk 文件）
         * 只读文件
         * 可执行文件
     * 提供许多（可定制的）映射来操作树：
@@ -78,13 +78,13 @@ NERD tree 提供以下特性和功能：
     * 在你浏览文件系统时，会创建或维护你的文件系统模型。这样做有以下几个优点：
         * 所有的文件系统信息将被缓存，并且只在需要的时候被重新读取
         * 如果你重新访问目录树中你以前的会话中访问过的部分，这个目录节点将保持
-          你之前打开/关闭它们时的状态
+          你之前打开或关闭它们时的状态
     * 插件会记住在 NERD tree 中的光标位置和窗口位置，这样你就可以把窗口隐藏
-      （或者直接关闭属性窗口），当再次打开它的时候（使用 NERDTreeToggle ），
+      （或者直接关闭属性窗口），当再次打开它的时候（使用 NERDTreeToggle），
       NERD tree 将出现在你最后使用过的位置
     * 你可以为每一个标签页打开一个不相关的 NERD tree，或者跨标签页共享树，或者
       混合使用上面两种方式
-    * 默认情况下，插件会替换默认的文件浏览器（ netrw ），所以如果你使用 :edit
+    * 默认情况下，插件会替换默认的文件浏览器（netrw），所以如果你使用 :edit
       编辑一个目录，一个（轻微修改过的）NERD tree 会出现在当前窗口中
     * 提供一个可编程的菜单系统（模拟右键点击一个节点上）
         * 提供一个执行基本的文件系统操作的默认菜单插件（新建、删除、移动或复制
@@ -105,7 +105,7 @@ NERD tree 提供以下特性和功能：
     如果指定了书签名，会使用书签相应的目录。
     例如： >
         :NERDTree /home/marty/vim7/src
-        :NERDTree foo   （ foo 是一个书签名）
+        :NERDTree foo   （foo 是一个书签名）
 <
 :NERDTreeFromBookmark <书签>                           *:NERDTreeFromBookmark*
     使用 <书签> 的目录作为根目录打开一个新的 NERD tree。使用该命令而不是
@@ -123,7 +123,7 @@ NERD tree 提供以下特性和功能：
     会询问使用哪一个作为镜像。
 
 :NERDTreeClose                                                *:NERDTreeClose*
-    在当前标签页中关闭 NERD tree 。
+    在当前标签页中关闭 NERD tree。
 
 :NERDTreeFind                                                  *:NERDTreeFind*
     在树中找到当前文件。
@@ -146,10 +146,10 @@ NERD tree 中的书签是一种标记感兴趣的文件或者目录的方式。�
 ------------------------------------------------------------------------------
 2.2.1. 书签表                                          *NERDTreeBookmarkTable*
 
-如果书签表被激活（参阅 |NERDTree-B| 和 |'NERDTreeShowBookmarks'| ），则会被渲
-染到树状图的上方，你可以双击书签或者使用 |NERDTree-o| 来激活选中文件。
+如果书签表被激活（参阅 |NERDTree-B| 和 |'NERDTreeShowBookmarks'|），则会被渲染
+到树状图的上方，你可以双击书签或者使用 |NERDTree-o| 来激活选中文件。
 
-另请参阅 |NERDTree-t| 和 |NERDTree-T| 。
+另请参阅 |NERDTree-t| 和 |NERDTree-T|。
 
 ------------------------------------------------------------------------------
 2.2.2. 书签命令                                     *NERDTreeBookmarkCommands*
@@ -184,7 +184,7 @@ NERD tree 中的书签是一种标记感兴趣的文件或者目录的方式。�
 :ReadBookmarks
     重新读取 |'NERDTreeBookmarksFile'| 中的书签。
 
-另请参阅 |:NERDTree| 和 |:NERDTreeFromBookmark| 。
+另请参阅 |:NERDTree| 和 |:NERDTreeFromBookmark|。
 
 ------------------------------------------------------------------------------
 2.2.3. 无效书签                                     *NERDTreeInvalidBookmarks*
@@ -272,7 +272,7 @@ A.......缩放（最大化/最小化）NERD tree 窗口......................|NE
 
 如果一个文件节点被选中，它会在前一个窗口中被打开，但是光标位置不会变。
 
-这个按键组合永远是 "g" + NERDTreeMapActivateNode （请参阅 |NERDTree-o| ）。
+这个按键组合永远是 "g" + NERDTreeMapActivateNode（请参阅 |NERDTree-o|）。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-t*
@@ -281,9 +281,9 @@ A.......缩放（最大化/最小化）NERD tree 窗口......................|NE
 应用对象： 文件和目录
 
 在一个新标签页中打开所选文件。如果一个目录被选中，在新标签页中为该目录打开一个
-新的 NERD tree 。
+新的 NERD tree。
 
-如果一个标记目录的书签被选中，在新标签页中为该目录打开一个新的 NERD tree 。如
+如果一个标记目录的书签被选中，在新标签页中为该目录打开一个新的 NERD tree。如
 果一个标记文件的书签被选中，在新标签页中打开那个文件。
 
 ------------------------------------------------------------------------------
@@ -310,7 +310,7 @@ A.......缩放（最大化/最小化）NERD tree 窗口......................|NE
 
 和 |NERDTree-i| 一样，只不过光标不会被移动。
 
-这个按键组合永远是 "g" + NERDTreeMapOpenSplit 的形式（请参阅 |NERDTree-i| ）。
+这个按键组合永远是 "g" + NERDTreeMapOpenSplit 的形式（请参阅 |NERDTree-i|）。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-s*
@@ -328,7 +328,7 @@ A.......缩放（最大化/最小化）NERD tree 窗口......................|NE
 
 和 |NERDTree-s| 一样，只不过光标不会被移动。
 
-这个按键组合永远是 "g" + NERDTreeMapOpenVSplit 的形式（请参阅 |NERDTree-s| ）。
+这个按键组合永远是 "g" + NERDTreeMapOpenVSplit 的形式（请参阅 |NERDTree-s|）。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-O*
@@ -339,7 +339,7 @@ A.......缩放（最大化/最小化）NERD tree 窗口......................|NE
 递归打开所选目录。
 
 所有文件和目录被缓存，但是如果一个目录由于文件过滤器（请参阅 |'NERDTreeIgnore'|
-|NERDTree-f| ）或者隐藏文件过滤器（请参阅 |'NERDTreeShowHidden'| ）而不被显示，
+|NERDTree-f|）或者隐藏文件过滤器（请参阅 |'NERDTreeShowHidden'|）而不被显示，
 那么它的内容不会被缓存。这样是便于使用的，尤其是当你有 .svn 目录的时候。
 
 ------------------------------------------------------------------------------
@@ -367,7 +367,7 @@ A.......缩放（最大化/最小化）NERD tree 窗口......................|NE
 应用对象： 文件和目录
 
 |:edit| 所选目录，或者所选文件的目录。依据 |'NERDTreeHijackNetrw'| 的设定，可
-以打开一个 NERD tree 或者一个 netrw 。
+以打开一个 NERD tree 或者一个 netrw。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-D*
@@ -481,7 +481,7 @@ A.......缩放（最大化/最小化）NERD tree 窗口......................|NE
 映射选项： NERDTreeMapMenu
 应用对象： 文件和目录
 
-显示 NERD tree 的菜单。详细请参阅 |NERDTreeMenu| 。
+显示 NERD tree 的菜单。详细请参阅 |NERDTreeMenu|。
 
 ------------------------------------------------------------------------------
                                                                  *NERDTree-cd*
@@ -513,7 +513,7 @@ A.......缩放（最大化/最小化）NERD tree 窗口......................|NE
 映射选项： NERDTreeMapToggleFilters
 应用对象： 没有限制
 
-切换是否使用文件过滤。详细请参阅 |'NERDTreeIgnore'| 。
+切换是否使用文件过滤。详细请参阅 |'NERDTreeIgnore'|。
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-F*
@@ -558,12 +558,12 @@ A.......缩放（最大化/最小化）NERD tree 窗口......................|NE
 ------------------------------------------------------------------------------
 2.4. NERD tree 菜单                                             *NERDTreeMenu*
 
-NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeMenuAPI| ）。这个
-主意是为了模拟大多数文件浏览器都具有的右键菜单。
+NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeMenuAPI|）。这个主
+意是为了模拟大多数文件浏览器都具有的右键菜单。
 
-这个插件有两个默认菜单插件： exec_menuitem.vim 和 fs_menu.vim 。 fs_menu.vim
-添加一些基本的新建、删除、移动或复制文件及目录的操作。 exec_menuitem.vim 提供
-了一个菜单项来执行可执行文件。
+这个插件有两个默认菜单插件： exec_menuitem.vim 和 fs_menu.vim。fs_menu.vim 添
+加一些基本的新建、删除、移动或复制文件及目录的操作。exec_menuitem.vim 提供了一
+个菜单项来执行可执行文件。
 
 相关标签： |NERDTree-m| |NERDTreeApi|
 
@@ -576,63 +576,63 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 
 提供下面的选项，可以定制 NERD tree 的行为。这些选项需要被设置在您的 vimrc 中。
 
-|'loaded_nerd_tree'|            不使用 NERD tree 插件。
+|'loaded_nerd_tree'|              不使用 NERD tree 插件。
 
-|'NERDTreeAutoCenter'|          当光标移动到距离顶部/底部指定的距离的时候，控
+|'NERDTreeAutoCenter'|            当光标移动到距离顶部/底部指定的距离的时候，控
                                 制 NERD tree 是否将光标所在位置自动设置为窗口
                                 的中心。
 
-|'NERDTreeAutoCenterThreshold'| 控制自动将光标位置居中的敏感度。
+|'NERDTreeAutoCenterThreshold'|   控制自动将光标位置居中的敏感度。
 
-|'NERDTreeCaseSensitiveSort'|   告诉 NERD tree 排序节点的时候是否大小写敏感。
+|'NERDTreeCaseSensitiveSort'|     告诉 NERD tree 排序节点的时候是否大小写敏感。
 
-|'NERDTreeSortHiddenFirst'|     告诉 NERD tree 排序节点的时候是否考虑隐藏文件
+|'NERDTreeSortHiddenFirst'|       告诉 NERD tree 排序节点的时候是否考虑隐藏文件
                                 开头的点号。
 
-|'NERDTreeChDirMode'|           告诉 NERD tree 什么情况下/什么时候它应该改变当
+|'NERDTreeChDirMode'|             告诉 NERD tree 什么情况下/什么时候它应该改变当
                                 前工作目录。
 
-|'NERDTreeHighlightCursorline'| 告诉 NERD tree 是否高亮光标所在行。
+|'NERDTreeHighlightCursorline'|   告诉 NERD tree 是否高亮光标所在行。
 
-|'NERDTreeHijackNetrw'|         告诉 NERD tree 是否替换 netrw 来浏览本地目录。
+|'NERDTreeHijackNetrw'|           告诉 NERD tree 是否替换 netrw 来浏览本地目录。
 
-|'NERDTreeIgnore'|              告诉 NERD tree 忽略哪些文件。
+|'NERDTreeIgnore'|                告诉 NERD tree 忽略哪些文件。
 
-|'NERDTreeRespectWildIgnore'|   告诉 NERD tree 是否考虑 |'wildignore'| 。
+|'NERDTreeRespectWildIgnore'|     告诉 NERD tree 是否考虑 |'wildignore'| 。
 
-|'NERDTreeBookmarksFile'|       指定书签存储位置。
+|'NERDTreeBookmarksFile'|         指定书签存储位置。
 
-|'NERDTreeBookmarksSort'|       显示书签的时候是否排序。
+|'NERDTreeBookmarksSort'|         显示书签的时候是否排序。
 
-|'NERDTreeMouseMode'|           告诉 NERD tree 如何处理鼠标点击。
+|'NERDTreeMouseMode'|             告诉 NERD tree 如何处理鼠标点击。
 
-|'NERDTreeQuitOnOpen'|          打开文件后关闭树窗口。
+|'NERDTreeQuitOnOpen'|            打开文件后关闭树窗口。
 
-|'NERDTreeShowBookmarks'|       告诉 NERD tree 启动时是否显示书签。
+|'NERDTreeShowBookmarks'|         告诉 NERD tree 启动时是否显示书签。
 
-|'NERDTreeShowFiles'|           告诉 NERD tree 启动时是否显示文件。
+|'NERDTreeShowFiles'|             告诉 NERD tree 启动时是否显示文件。
 
-|'NERDTreeShowHidden'|          告诉 NERD tree 启动时是否显示隐藏文件。
+|'NERDTreeShowHidden'|            告诉 NERD tree 启动时是否显示隐藏文件。
 
-|'NERDTreeShowLineNumbers'|     告诉 NERD tree 树窗口中是否显示行号。
+|'NERDTreeShowLineNumbers'|       告诉 NERD tree 树窗口中是否显示行号。
 
-|'NERDTreeSortOrder'|           告诉 NERD tree 如何排序节点。
+|'NERDTreeSortOrder'|             告诉 NERD tree 如何排序节点。
 
-|'NERDTreeStatusline'|          给 NERD tree 窗口设置一个状态栏。
+|'NERDTreeStatusline'|            给 NERD tree 窗口设置一个状态栏。
 
-|'NERDTreeWinPos'|              告诉插件把 NERD tree 窗口放置在哪儿。
+|'NERDTreeWinPos'|                告诉插件把 NERD tree 窗口放置在哪儿。
 
-|'NERDTreeWinSize'|             设置 NERD tree 窗口被打开时的大小。
+|'NERDTreeWinSize'|               设置 NERD tree 窗口被打开时的大小。
 
-|'NERDTreeMinimalUI'|           禁止显示 'Bookmarks' 和 'Press ? for help' 。
+|'NERDTreeMinimalUI'|             禁止显示 'Bookmarks' 和 'Press ? for help'。
 
-|'NERDTreeDirArrows'|           告诉 NERD tree 显示目录的时候使用箭头代替 + ~ 。
+|'NERDTreeDirArrows'|             告诉 NERD tree 显示目录的时候使用箭头代替 + ~ 。
 
 |'NERDTreeCascadeOpenSingleChildDir'|
                                 当所选目录只有一个子节点并且该节点是目录的时
                                 候，级联展开。
 
-|'NERDTreeAutoDeleteBuffer'|    告诉 NERD tree 当文件被上下文菜单命令删除或重
+|'NERDTreeAutoDeleteBuffer'|      告诉 NERD tree 当文件被上下文菜单命令删除或重
                                 命名的时候，自动删除缓冲区。
 
 ------------------------------------------------------------------------------
@@ -650,7 +650,7 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 取值范围： 0 或 1
 默认值： 1
 
-如果设置为 1 ，当光标移动到距顶部/底部的行数是 |'NERDTreeAutoCenterThreshold'|
+如果设置为 1，当光标移动到距顶部/底部的行数是 |'NERDTreeAutoCenterThreshold'|
 指定的行范围以内的时候，NERD tree 窗口会将光标所在位置自动设置为窗口的中心。
 
 这个选项只会对树导航映射作出反应，
@@ -664,7 +664,7 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 取值范围： 任何自然数。
 默认值： 3
 
-这个选项控制自动居中的敏感度，详细请参阅 |'NERDTreeAutoCenter'| 。
+这个选项控制自动居中的敏感度，详细请参阅 |'NERDTreeAutoCenter'|。
 
 ------------------------------------------------------------------------------
                                                  *'NERDTreeCaseSensitiveSort'*
@@ -678,7 +678,7 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
     boner.c
     Foo.c
 <
-但是，如果你把选项设置为 1 ，上面的节点会按下面的方式排序： >
+但是，如果你把选项设置为 1，上面的节点会按下面的方式排序： >
     Baz.c
     Foo.c
     bar.c
@@ -693,28 +693,28 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 
 用这个选项告诉插件什么时候（如果真的需要）改变 Vim 的当前工作目录（CWD）。
 
-如果设置为 0 ，当前工作目录（CWD）永远不会被 NERD tree 改变。
+如果设置为 0，当前工作目录（CWD）永远不会被 NERD tree 改变。
 
-如果设置为 1 ，当前工作目录（CWD）会在第一次加载 NERD tree 的时候被改变为它初
-始化的目录。比如：
+如果设置为 1，当前工作目录（CWD）会在第一次加载 NERD tree 的时候被改变为它初始
+化的目录。比如：
 
-如果你使用下面的命令启动 NERD tree ： >
+如果你使用下面的命令启动 NERD tree： >
     :NERDTree /home/marty/foobar
 <
 然后当前工作目录（CWD）会被改变为 /home/marty/foobar 并且不会被再次改变，除非
-你使用相似的命令初始化了另一个 NERD tree 。
+你使用相似的命令初始化了另一个 NERD tree。
 
-如果这个选项被设置为 2 ，插件的行为和被设置为 1 类似，只不过当树的根目录被改变的时
-候当前工作目录（CWD）也会被改变。例如，如果当前工作目录（CWD）是
+如果这个选项被设置为 2，插件的行为和被设置为 1 类似，只不过当树的根目录被改变
+的时候当前工作目录（CWD）也会被改变。例如，如果当前工作目录（CWD）是
 /home/marty/foobar 并且你把 /home/marty/foobar/baz 设置为了新的根节点，当前工
-作目录（CWD）也会被改变为 /home/marty/foobar/baz 。
+作目录（CWD）也会被改变为 /home/marty/foobar/baz。
 
 ------------------------------------------------------------------------------
                                                *'NERDTreeHighlightCursorline'*
 取值范围： 0 或 1
 默认值： 1
 
-如果设置为 1 ，NERD tree 缓冲区内的当前光标所在行会被高亮，使用 |'cursorline'|
+如果设置为 1，NERD tree 缓冲区内的当前光标所在行会被高亮，使用 |'cursorline'|
 来完成。
 
 ------------------------------------------------------------------------------
@@ -722,14 +722,14 @@ NERD tree 有一个可以通过 API 编程的菜单（详细请参阅 |NERDTreeM
 取值范围： 0 或 1
 默认值： 1
 
-如果设置为 1 ，当执行 >
+如果设置为 1，当执行 >
     :edit <some directory>
 <
-会在目标窗口打开一个“次等”的 NERD tree 来代替 netrw 。
+会在目标窗口打开一个“次等”的 NERD tree 来代替 netrw。
 
 “次等”的 NERD tree 在下面几个方面和普通的有所区别：
     1. 'o' 会在和树同一个窗口打开文件，替换掉当前打开的内容。
-    2. 在同一个标签页内你可以有任意多的“次等”的 NERD tree 。
+    2. 在同一个标签页内你可以有任意多的“次等”的 NERD tree。
 
 ------------------------------------------------------------------------------
                                                             *'NERDTreeIgnore'*
@@ -762,31 +762,31 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 取值范围： 0 或 1
 默认值： 0
 
-如果设置为 1 ，会考虑 |'wildignore'| 选项。
+如果设置为 1，会考虑 |'wildignore'| 选项。
 
 ------------------------------------------------------------------------------
                                                      *'NERDTreeBookmarksFile'*
 取值范围： a path
 默认值： $HOME/.NERDTreeBookmarks
 
-指定书签存储位置。详细请参阅 |NERDTreeBookmarkCommands| 。
+指定书签存储位置。详细请参阅 |NERDTreeBookmarkCommands|。
 
 ------------------------------------------------------------------------------
                                                      *'NERDTreeBookmarksSort'*
 取值范围： 0 或 1
 默认值： 1
 
-如果设置为 0 ，书签表不会被排序。
-如果设置为 1 ，书签表会被排序。
+如果设置为 0，书签表不会被排序。
+如果设置为 1，书签表会被排序。
 
 ------------------------------------------------------------------------------
                                                          *'NERDTreeMouseMode'*
 取值范围： 1，2 或 3
 默认值： 1
 
-如果设置为 1 ，双击一个节点会打开它。
-如果设置为 2 ，单击一个节点会打开目录节点，文件节点需要双击才会打开。
-如果设置为 3 ，单击会打开任何类型的节点。
+如果设置为 1，双击一个节点会打开它。
+如果设置为 2，单击一个节点会打开目录节点，文件节点需要双击才会打开。
+如果设置为 3，单击会打开任何类型的节点。
 
 注意：双击树节点所在行的任何位置都会激活它，但是所有单击激活必须单击节点名称。
 例如，如果有下面的节点： >
@@ -799,15 +799,15 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 取值范围： 0 或 1
 默认值： 0
 
-如果设置为 1 ，NERD tree 窗口会在用下面的映射打开文件后被关闭： |NERDTree-o| ，
-|NERDTree-i| ， |NERDTree-t| 和 |NERDTree-T| 。
+如果设置为 1，NERD tree 窗口会在用下面的映射打开文件后被关闭：|NERDTree-o|，
+|NERDTree-i|，|NERDTree-t| 和 |NERDTree-T|。
 
 ------------------------------------------------------------------------------
                                                      *'NERDTreeShowBookmarks'*
 取值范围： 0 或 1
 默认值： 0
 
-如果选项设置为 1 ，会显示书签表。
+如果选项设置为 1，会显示书签表。
 
 这个选项可以被每个树动态切换，使用 |NERDTree-B| 的按键映射。
 
@@ -816,10 +816,11 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 取值范围： 0 或 1
 默认值： 1
 
-如果这个选项被设置为 1 ，会在 NERD tree 中显示文件。如果设置为 0，只有目录被显示。
+如果这个选项被设置为 1，会在 NERD tree 中显示文件。如果设置为 0，只有目录被显
+示。
 
-这个选项可以被每个树动态切换，使用 |NERDTree-F| 的按键映射，并且在你需要导
-航到树的某个部分的时候可以大幅缩减树的节点。
+这个选项可以被每个树动态切换，使用 |NERDTree-F| 的按键映射，并且在你需要导航到
+树的某个部分的时候可以大幅缩减树的节点。
 
 ------------------------------------------------------------------------------
                                                         *'NERDTreeShowHidden'*
@@ -885,7 +886,7 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 
 ------------------------------------------------------------------------------
                                                             *'NERDTreeWinPos'*
-取值范围： "left" （意为左边） 或 "right" （意为右边）
+取值范围： "left"（意为左边） 或 "right"（意为右边）
 默认值： "left"
 
 这个选项用来决定 NERD tree 窗口被显示在屏幕的什么位置。
@@ -917,7 +918,7 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 默认值： 0
 
 这个选项用来改变树中目录节点的默认外观。当这个选项设置为 0 的时候，会使用老式
-的长条（|），+ ，~ 字符。当设置为 1 的时候使用右箭头和下箭头。使用下面方式设置
+的长条（|），+，~ 字符。当设置为 1 的时候使用右箭头和下箭头。使用下面方式设置
 这个选项： >
     let NERDTreeDirArrows=0
     let NERDTreeDirArrows=1
@@ -943,7 +944,7 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 
 当使用上下文菜单来删除或重命名文件的时候，你可能也想删除那个不再可用的缓冲区。
 这个选项没有被设置的时候，你会看到一个询问你是否真的想删除旧的缓冲区的确认信
-息。如果你总是按 'y' ，那么值得把这个选项设置为 1 。
+息。如果你总是按 'y' ，那么值得把这个选项设置为 1。
 使用下面的方式来设置这个选项： >
     let NERDTreeAutoDeleteBuffer=0
     let NERDTreeAutoDeleteBuffer=1
@@ -953,8 +954,8 @@ NERD tree 被渲染的时候，被 'NERDTreeIgnore' 中的正则表达式匹配�
 4. NERD tree API                                                 *NERDTreeAPI*
 
 NERD tree 插件允许你通过 API 添加自定义的按键映射和菜单项。任何使用 API 的脚本
-需要被放在 ~/.vim/nerdtree_plugin/ （ *nix 系统）或 ~/vimfiles/nerdtree_plugin
-（ Windows 系统）。
+需要被放在 ~/.vim/nerdtree_plugin/ （*nix 系统）或 ~/vimfiles/nerdtree_plugin
+（Windows 系统）。
 
 插件导出了一些可以用来操作树和/或从中获得信息的原型对象： >
     g:NERDTreePath
@@ -979,8 +980,8 @@ NERDTreeAddKeyMap({options})                             *NERDTreeAddKeyMap()*
     {options} 必须是一个字典类型，且必须包含下面的键：
     "key" - 新映射的触发键
     "callback" - 新按键映射的处理函数
-    "quickhelpText" - 在快速帮助中显示的文本（详细请参阅 |NERDTree-?| ）
-    "override" - 如果为 1 ，那么新的按键映射会覆盖该按键及作用域组合的任何先前
+    "quickhelpText" - 在快速帮助中显示的文本（详细请参阅 |NERDTree-?|）
+    "override" - 如果为 1，那么新的按键映射会覆盖该按键及作用域组合的任何先前
     定义的映射。可以用来覆盖默认的按键映射。
 
     此外，可以提供一个 "scope" 参数。限制按键映射只在光标在确定的对象上时才被
@@ -1020,14 +1021,14 @@ NERDTreeAddSubmenu({options})                           *NERDTreeAddSubmenu()*
 
     下面的键是可选的：
     "isActiveCallback" - 一个用来决定这个子菜单是否被显示的快捷键。这个回调函
-    数必须返回 0 或 1 。
+    数必须返回 0 或 1。
     "parent" - 新的子菜单的父菜单（从前一个 NERDTreeAddSubmenu() 的调用返回）。
     如果这个键没有指定值，那么新的子菜单会被现实在顶级菜单中。
 
     参考下面的例子。
 
 NERDTreeAddMenuItem({options})                         *NERDTreeAddMenuItem()*
-    在 NERD tree 菜单中添加一个新的菜单项（详细请参阅 |NERDTreeMenu| ）。
+    在 NERD tree 菜单中添加一个新的菜单项（详细请参阅 |NERDTreeMenu|）。
 
     {options} 必须是一个字典类型，必须包含下面的键：
     "text" - 显示给用户看的菜单项的文本
@@ -1036,7 +1037,7 @@ NERDTreeAddMenuItem({options})                         *NERDTreeAddMenuItem()*
 
     下面的键是可选的：
     "isActiveCallback" - 一个用来决定这个菜单项是否被显示的快捷键。这个回调函
-    数必须返回 0 或 1 。
+    数必须返回 0 或 1。
     "parent" - 如果这个菜单项属于某个子菜单，那么这个键必须被设置。这个键的值
     需要被设置为使用 |NERDTreeAddSubmenu()| 创建子菜单时返回的那个对象。
 
@@ -1091,10 +1092,10 @@ NERDTreeRender()                                            *NERDTreeRender()*
 ==============================================================================
 5. 关于                                                        *NERDTreeAbout*
 
-NERD tree 的作者是一只叫“妈斯拉”（ Martyzilla ）的十分可怕的怪兽，他在早餐的时
+NERD tree 的作者是一只叫“妈斯拉”（Martyzilla）的十分可怕的怪兽，他在早餐的时
 候配着牛奶和糖大口地吞食小孩子。
 
-他的电子邮件地址为 martin.grenfell 艾特 gmail 点 com 。他很乐意聆听你的反馈，
+他的电子邮件地址为 martin.grenfell 艾特 gmail 点 com。他很乐意聆听你的反馈，
 所以请把你对这个插件的建议和/或评论直接发送给他。不要害羞 --- 他能做的最坏的
 事情也不过是把你给宰了，然后冷藏到冰箱里面晚一点再吃 ;)
 
@@ -1129,8 +1130,8 @@ NERD tree 的作者是一只叫“妈斯拉”（ Martyzilla ）的十分可怕�
 
 4.1.0
     新特性：
-    - 添加 NERDTreeFind 来展现树的当前缓冲区，请参阅 |NERDTreeFind| 。这实际上
-      合并了 FindInNERDTree 插件（作者 Doug McInnes ）到本脚本中。
+    - 添加 NERDTreeFind 来展现树的当前缓冲区，请参阅 |NERDTreeFind|。这实际上
+      合并了 FindInNERDTree 插件（作者 Doug McInnes）到本脚本中。
     - NERDTreeQuitOnOpen 对 t/T 映射生效。感谢 Stefan Ritter 和 Rémi Prévost
     - 如果比树窗口宽，缩短根节点。感谢 Victor Gonzalez 。
 
@@ -1147,12 +1148,12 @@ NERD tree 的作者是一只叫“妈斯拉”（ Martyzilla ）的十分可怕�
     - 添加一个新的映射来最大化/还原 NERD tree 的窗口，感谢
       Guillaume Duranceau 的补丁。详细请参阅 :help NERDTree-A 。
 
-    - 修复次等的 NERD tree （ netrw 替换树） 和 NERDTreeQuitOnOpen
-      选项共存的问题，感谢 Curtis Harvey 。
+    - 修复次等的 NERD tree（netrw 替换树）和 NERDTreeQuitOnOpen 选项共存的问
+      题，感谢 Curtis Harvey 。
     - 修复插件忽略以点号结尾的目录的问题，感谢 Aggelos Orfanakos 的补丁。
     - 修复 x 按键在树的根节点的问题，感谢 Bryan Venteicher 的补丁。
-    - 修复 NERD tree 缓冲区内的光标位置/窗口大小在关闭时没有被正确存储的
-      问题，感谢 Richard Hart 。
+    - 修复 NERD tree 缓冲区内的光标位置/窗口大小在关闭时没有被正确存储的问题，
+      感谢 Richard Hart 。
     - 修复 NERDTreeMirror 镜像错误的树的问题
 
 3.1.1
@@ -1186,7 +1187,7 @@ NERD tree 的作者是一只叫“妈斯拉”（ Martyzilla ）的十分可怕�
     错误修复:
     - 修复 'hidden' 没有设置时 :NERDTreeToggle 和 :NERDTreeMirror 中的错误
     - 修复当 <path> 是相对路径并且没有以 ./ 或 ../ 开头的时候，
-      :NERDTree <path> 会失败的错误，感谢 James Kanze 。
+      :NERDTree <path> 会失败的错误，感谢 James Kanze。
     - 使按键映射 q 对次等（ :e <dir> 形式） NERD tree 生效，感谢 jamessan
     - 修复次等 NERD tree 中大把的错误。
 
@@ -1273,7 +1274,7 @@ NERD tree 而干脆去下载毛片了。
 ==============================================================================
 8. 授权协议                                                  *NERDTreeLicense*
 
-NERD tree 基于“你他妈的想干嘛就干嘛公共许可证”（ WTFPL ）发布。
+NERD tree 基于“你他妈的想干嘛就干嘛公共许可证”（WTFPL）发布。
 参阅 http://sam.zoy.org/wtfpl/COPYING 。
 
 ==============================================================================


### PR DESCRIPTION
完善 `NERD_tree.vim` 的文档翻译

接续 https://github.com/vimcn/NERD_tree.vim.cnx/pull/4 继续审阅修改。

基于 https://github.com/scrooloose/nerdtree/tree/b33d6daf0bd22a068ba1429b920374c220eae7d6/doc/NERD_tree.txt 文件进行审阅修改。

* 数字之前增加一个空格
https://github.com/vimcn/NERD_tree.vim.cnx/pull/4#discussion_r25575174

* 修正“即”的格式
https://github.com/vimcn/NERD_tree.vim.cnx/pull/4#discussion_r25574970
https://github.com/vimcn/NERD_tree.vim.cnx/pull/4#discussion_r25575129

* 修正“/”的用法
https://github.com/vimcn/NERD_tree.vim.cnx/pull/4#discussion_r25574721
https://github.com/vimcn/NERD_tree.vim.cnx/pull/4#discussion_r25574737
https://github.com/vimcn/NERD_tree.vim.cnx/pull/4#discussion_r25574783
https://github.com/vimcn/NERD_tree.vim.cnx/pull/4#discussion_r25575145

* 修正一句话
https://github.com/vimcn/NERD_tree.vim.cnx/pull/4#discussion_r25574824

* 修正 “前”-“后” 为 “上”-“下”
https://github.com/vimcn/NERD_tree.vim.cnx/pull/4#discussion_r25575088
https://github.com/vimcn/NERD_tree.vim.cnx/pull/4#discussion_r26721019

* 修正部分句子缺少句号

* 其它修正

此致！ :bow: 